### PR TITLE
Support mediastreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ dimensions.depth = bb.size().z
 
 
 ### Using a MediaStream as input
+Several APIs have been exposed to allow for dynamic switching between audio files and ```MediaStream```s (obtained from, for example, WebRTC).
 ```html
 <a-assets>
   <audio id="track" src="assets/audio/track.mp3"></audio>
@@ -128,17 +129,18 @@ dimensions.depth = bb.size().z
     src=""></a-resonance-audio-src>
 </a-resonance-audio-room>
 ```
-Use javascript to assign a ```MediaStream``` obtained from, for example, WebRTC. Note that the src attribute must be set but can be left empty.
+The APIs exposed are available on the element having the component and the component itself:
 ```js
+document.querySelector('a-resonance-audio-src').srcObject = stream
 document.querySelector('a-resonance-audio-src').setAttribute('srcObject', stream)
-// Or:
 document.querySelector('a-resonance-audio-src').components['resonance-audio-src'].setMediaStream(stream)
-```
-Switching to and from audio files is also possible:
-```js
+
+document.querySelector('a-resonance-audio-src').src = '#track'
 document.querySelector('a-resonance-audio-src').setAttribute('src', '#track')
+document.querySelector('a-resonance-audio-src').components['resonance-audio-src'].setMediaSrc('assets/audio/track.mp3')
 ```
-This has one limitation: when switching back to an audio file, the resulting src value must be different than the previous value. When going from an audio file to a stream and back to the same audio file again, this can be done by setting src to '' right before switching to a stream.
+As ```setMediaSrc()``` bypasses A-Frame's updater, the property type it accepts is not asset, but string. The ```setAttribute()``` interface works only on the primitives.
+
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -137,9 +137,8 @@ document.querySelector('a-resonance-audio-src').components['resonance-audio-src'
 
 document.querySelector('a-resonance-audio-src').src = '#track'
 document.querySelector('a-resonance-audio-src').setAttribute('src', '#track')
-document.querySelector('a-resonance-audio-src').components['resonance-audio-src'].setMediaSrc('assets/audio/track.mp3')
+document.querySelector('a-resonance-audio-src').components['resonance-audio-src'].setMediaSrc('#track')
 ```
-As ```setMediaSrc()``` bypasses A-Frame's updater, the property type it accepts is not asset, but string. The ```setAttribute()``` interface works only on the primitives.
 
 
 ***

--- a/README.md
+++ b/README.md
@@ -107,6 +107,39 @@ dimensions.height = bb.size().y
 dimensions.depth = bb.size().z
 ```
 
+
+### Using a MediaStream as input
+```html
+<a-assets>
+  <audio id="track" src="assets/audio/track.mp3"></audio>
+</a-assets>
+<a-resonance-audio-room
+  material="wireframe:true"
+  position="0 0 -5"
+  width="4"
+  height="4"
+  depth="4"
+  ambisonic-order="3"
+  speed-of-sound="343"
+  left="brick-bare" right="curtain-heavy" front="plywood-panel" 
+  back="glass-thin" down="parquet-on-concrete" up="acoustic-ceiling-tiles">
+  <a-resonance-audio-src
+    position="0 0 0"
+    src=""></a-resonance-audio-src>
+</a-resonance-audio-room>
+```
+Use javascript to assign a ```MediaStream``` obtained from, for example, WebRTC. Note that the src attribute must be set but can be left empty.
+```js
+document.querySelector('a-resonance-audio-src').setAttribute('srcObject', stream)
+// Or:
+document.querySelector('a-resonance-audio-src').components['resonance-audio-src'].setMediaStream(stream)
+```
+Switching to and from audio files is also possible:
+```js
+document.querySelector('a-resonance-audio-src').setAttribute('src', '#track')
+```
+This has one limitation: when switching back to an audio file, the resulting src value must be different than the previous value. When going from an audio file to a stream and back to the same audio file again, this can be done by setting src to '' right before switching to a stream.
+
 ***
 
 **Credits:**

--- a/examples/index.html
+++ b/examples/index.html
@@ -10,6 +10,7 @@
     <h1>A-Frame Resonance Audio Component</h1>
     <a href="entities/">Basic usage with entities</a>
     <a href="primitives/">Basic usage with primitives</a>
+    <a href="primitives-using-Mediastream/">Basic usage with primitives and MediaStream</a>
     <a href="using-obj-model-as-room/">Using obj-model as room</a>
     <!-- GitHub Corner. -->
     <a href="https://github.com/mkungla/aframe-resonance-audio-component" class="github-corner" aria-label="View source on Github"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>

--- a/examples/primitives-using-MediaStream/index.html
+++ b/examples/primitives-using-MediaStream/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Basic usage with primitives | A-Frame Resonance Audio Component</title>
+    <script src="https://cdn.jsdelivr.net/npm/aframe@0.7.1"></script>
+    <script src="../aframe-resonance-audio-component.js"></script>
+  </head>
+  <body>
+
+    <audio id="streamSrcFile" src="../assets/audio/track.mp3"></audio>
+
+    <a-scene>
+      <a-resonance-audio-room
+        material="wireframe:true"
+        position="0 0 -5"
+        width="4"
+        height="4"
+        depth="4"
+        ambisonic-order="3"
+        speed-of-sound="343"
+        left="brick-bare"
+        right="curtain-heavy"
+        front="plywood-panel"
+        back="glass-thin"
+        down="parquet-on-concrete"
+        up="acoustic-ceiling-tiles">
+        <a-resonance-audio-src
+          position="0 0 0"
+          src=""></a-resonance-audio-src>
+      <a-resonance-audio-room>
+      <a-sky color="#6EBAA7"></a-sky>
+
+    </a-scene>
+    <!-- GitHub Corner. -->
+    <a href="https://github.com/mkungla/aframe-resonance-audio-component" class="github-corner" aria-label="View source on Github"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
+
+    <script>
+    window.setTimeout(function(){
+      let srcEl = document.querySelector('#streamSrcFile')
+
+      if (!srcEl.mozCaptureStream) {
+        window.alert('Currently only Firefox supports proper stream capturing from audio elements. Chrome does not include the proper audio tracks and Edge does not support capturing streams at all.');
+        // Continue so the user can see the error.
+      }
+
+      // Turn audio element into stream.
+      let captureStream = srcEl.mozCaptureStream || srcEl.captureStream || function(){throw new Error('browser does not support capture into stream')}
+      let stream = captureStream.call(srcEl)
+      
+      // Set resonance audio src to stream.
+      document.querySelector('a-resonance-audio-src').setAttribute('srcObject', stream)
+
+      // Start stream.
+      srcEl.play()
+
+    }, 3000);
+    </script>
+  </body>
+</html>

--- a/examples/primitives-using-MediaStream/index.html
+++ b/examples/primitives-using-MediaStream/index.html
@@ -37,6 +37,8 @@
 
     <script>
     window.setTimeout(function(){
+
+      // This is only to show that the component works with streams, by turning an audio file into a stream.
       let srcEl = document.querySelector('#streamSrcFile')
 
       if (!srcEl.mozCaptureStream) {

--- a/src/resonance-audio-room.js
+++ b/src/resonance-audio-room.js
@@ -166,7 +166,11 @@ AFRAME.registerComponent('resonance-audio-room', {
     }
 
     // Looping
-    this.el.audioElement.setAttribute('loop', this.sound.data.loop)
+    if (this.sound.data.loop) {
+      this.el.audioElement.setAttribute('loop', 'true')
+    } else {
+      this.el.audioElement.removeAttribute('loop')
+    }
   },
 
   connectStreamSrc (stream) {

--- a/src/resonance-audio-src.js
+++ b/src/resonance-audio-src.js
@@ -18,7 +18,7 @@ AFRAME.registerComponent('resonance-audio-src', {
   },
   update (oldData) {
     if (Object.keys(oldData).length > 0 && // Skip initialization (this is done by the room).
-        oldData.src != this.data.src       // Only connect if src was changed.
+        oldData.src != this.data.src       // Only connect if src was changed and not if other properties were changed.
         ) {
       this.room.connectElementSrc(this.data.src)
     }
@@ -27,7 +27,7 @@ AFRAME.registerComponent('resonance-audio-src', {
     if (!(mediaStream instanceof MediaStream) && mediaStream != null) {
       throw new TypeError('not a mediastream')
     }
-    this.room.connectStreamSrc(mediaStream);
+    this.room.connectStreamSrc(mediaStream)
   },
   getSource () {
     return this.data.src

--- a/src/resonance-audio-src.js
+++ b/src/resonance-audio-src.js
@@ -7,14 +7,13 @@ AFRAME.registerComponent('resonance-audio-src', {
   multiple: false,
 
   schema: {
-    src: {type: 'asset', default: ''},
+    src: {type: 'asset'},
     loop: {type: 'boolean', default: true},
     autoplay: {type: 'boolean', default: true}
   },
   init () {
     this.pos = new AFRAME.THREE.Vector3()
     this.room = null
-    this.mediaStream = null
     this.exposeAPI()
   },
   exposeAPI() {
@@ -24,7 +23,7 @@ AFRAME.registerComponent('resonance-audio-src', {
     }
     const descriptor_srcObject = { 
       set: (value) => { this.setMediaStream(value) },
-      get: ()      => this.mediaStream
+      get: ()      => this.data.srcObject
     }
     Object.defineProperty(this.el, 'src', descriptor_src)
     Object.defineProperty(this.el, 'srcObject', descriptor_srcObject)
@@ -32,12 +31,14 @@ AFRAME.registerComponent('resonance-audio-src', {
     Object.defineProperty(this, 'srcObject', descriptor_srcObject)
   },
   setMediaSrc (src) {
+    // Simplified asset parsing, similar to the one used by A-Frame.
     if (typeof src !== 'string') { throw new TypeError('invalid src') }
     if (src.charAt(0) === '#') {
       const el = document.querySelector(src)
       if (!el) { throw new Error('invalid src') }
       src = el.getAttribute('src')
     }
+    this.data.srcObject = null
     this.data.src = src
     this.room.connectElementSrc(src)
   },
@@ -45,7 +46,8 @@ AFRAME.registerComponent('resonance-audio-src', {
     if (!(mediaStream instanceof MediaStream) && mediaStream != null) {
       throw new TypeError('not a mediastream')
     }
-    this.mediaStream = mediaStream
+    this.data.src = ''
+    this.data.srcObject = mediaStream
     this.room.connectStreamSrc(mediaStream)
   },
   getSource () {


### PR DESCRIPTION
**Description:**
This allows the use of MediaStream objects to be added to a Google Resonance room.

**Changes proposed:**
It stores the relevant AudioNode objects so they can be disconnected and reconnected at will. The audio-src element exposes an API that allows updating the src or srcObject (which allows stream).